### PR TITLE
Add UT support

### DIFF
--- a/worlds/mk64/Courses.py
+++ b/worlds/mk64/Courses.py
@@ -29,7 +29,11 @@ hard_course_pool = medium_course_pool + [KTB, RoR, BC]
 
 
 def determine_order(world: "MK64World") -> list[int]:
-    random = world.multiworld.random
+    # if using Universal Tracker, we've already filled in the course order
+    if world.using_ut:
+        return world.course_order
+
+    random = world.random
     opt = world.opt
 
     match opt.course_order:

--- a/worlds/mk64/Items.py
+++ b/worlds/mk64/Items.py
@@ -45,7 +45,7 @@ def create_items(world: "MK64World"):
     opt = world.opt
     num_filler = world.num_filler_items
     itempool = world.multiworld.itempool
-    random = world.multiworld.random
+    random = world.random
 
     item_group_mask = (Group.base
                        | (opt.feather and Group.feather)
@@ -89,10 +89,17 @@ def create_items(world: "MK64World"):
             filler_items.append(name)
         elif group == Group.trap:
             trap_items.append(name)
-    for _ in range(1 + opt.two_player):
-        kart_index = random.randrange(len(karts))
-        world.multiworld.push_precollected(create_item(karts[kart_index], player, ItemClassification.progression))
-        world.starting_karts.append(karts.pop(kart_index))
+
+    # if using Universal Tracker, read from the starting karts we got from slot data
+    if world.using_ut:
+        for kart in world.starting_karts:
+            world.multiworld.push_precollected(create_item(kart, player, ItemClassification.progression))
+            karts.remove(kart)
+    else:
+        for _ in range(1 + opt.two_player):
+            kart_index = random.randrange(len(karts))
+            world.multiworld.push_precollected(create_item(karts[kart_index], player, ItemClassification.progression))
+            world.starting_karts.append(karts.pop(kart_index))
     for kart in karts:
         itempool.append(create_item(kart, player))
     for _ in range(round(num_filler * (100 - opt.trap_percentage) * 0.01)):

--- a/worlds/mk64/Rules.py
+++ b/worlds/mk64/Rules.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 from BaseClasses import CollectionState
-from ..generic.Rules import add_rule, set_rule
+from worlds.generic.Rules import add_rule, set_rule
 
 from .Locations import course_locations, Group, shared_hazard_locations, cup_locations, cup_events
 from .Options import Opt, GameMode, Goal, CupTrophyLocations


### PR DESCRIPTION
Adds Universal Tracker support, so that you can use Universal Tracker to see which checks are currently in logic.
Also swapped some uses of multiworld.random to world.random, and fixed an import that should be absolute.
Something I wasn't sure about was filler_spots and shuffle_clusters -- the intent is to just have it fill all of those locations, since UT filters out locations that don't exist.
